### PR TITLE
Git command changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For projects that use JUnit:
 For projects in the project hierarchy:
 
 - `org.metaborg.gradle.config.devenv`  
-  For the root `/build.gradle.kts`
+  For the root `/build.gradle.kts`, provides Git version control commands
 - `org.metaborg.gradle.config.devenv-settings`  
   For the root `/settings.gradle.kts`
 - `org.metaborg.gradle.config.root-project`  
@@ -45,8 +45,8 @@ Include the required plugins in the `build.gradle.kts` file's `plugins` block,
 like this:
 
     plugins {
-    id("org.metaborg.gradle.config.java-library")
-    id("org.metaborg.gradle.config.junit-testing")
+      id("org.metaborg.gradle.config.java-library")
+      id("org.metaborg.gradle.config.junit-testing")
     }
 
 
@@ -66,3 +66,18 @@ First, ensure your changes work correctly by [enabling the plugin](#development)
 and building the project. Then push the changes to the `develop` branch.
 Once the online build succeeds, merge the develop branch with `master`
 and tag the commit to make a release. The tag format is: `release-1.2.3`.
+
+
+## Git Version Control Tasks
+The `org.metaborg.gradle.config.devenv` plugin, applied to the root of
+this project, provides tasks for Git version control. The most important
+tasks are:
+
+- `repoStatus` — Provides the status of the repository.
+- `repoUpdate` — Updates the repositories.
+- `repoPush` — Pushes the current branch of the repository.
+
+To list all tasks, issue:
+
+    ./gradlew tasks
+

--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvPlugin.kt
@@ -134,12 +134,12 @@ class DevenvPlugin : Plugin<Project> {
       doLast {
         for(repo in repos) {
           if(!repo.update) continue
-          println("Pushing all branches for repository ${repo.dirPath}:")
+          println("Pushing all branches and annotated tags for repository ${repo.dirPath}:")
           repo.pushAllTags(project)
           println()
         }
       }
-      description = "For each Git repository of devenv for which update is set to true: push all local tags to the main remote."
+      description = "For each Git repository of devenv for which update is set to true: push all local branches and annotated tags to the main remote."
     }
 
     // Shutdown JGit work queue after build is finished to free resources.

--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvPlugin.kt
@@ -108,6 +108,17 @@ class DevenvPlugin : Plugin<Project> {
       }
       description = "For each Git repository of devenv for which update is set to true: push the current local branch to the main remote."
     }
+    project.tasks.register<DevenvTask>("repoPushTags") {
+      doLast {
+        for(repo in repos) {
+          if(!repo.update) continue
+          println("Pushing current branch and annotated tags for repository ${repo.dirPath}:")
+          repo.pushTags(project)
+          println()
+        }
+      }
+      description = "For each Git repository of devenv for which update is set to true: push the current local branch and annotated tags to the main remote."
+    }
     project.tasks.register<DevenvTask>("repoPushAll") {
       doLast {
         for(repo in repos) {

--- a/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
@@ -72,7 +72,7 @@ class Repo(
   }
 
   fun pull(rootProject: Project) {
-    execGitCmd(rootProject, "pull", "--quiet", "--recurse-submodules", "--rebase")
+    execGitCmd(rootProject, "pull", "--quiet", "--recurse-submodules", "--rebase", "--autostash")
   }
 
   fun push(rootProject: Project) {

--- a/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
@@ -80,7 +80,7 @@ class Repo(
   }
 
   fun pushAllTags(rootProject: Project) {
-    execGitCmd(rootProject, "push", "--tags")
+    execGitCmd(rootProject, "push", "--follow-tags")
   }
 
   fun pushAll(rootProject: Project) {

--- a/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
@@ -87,6 +87,10 @@ class Repo(
     execGitCmd(rootProject, "push", "--all")
   }
 
+  fun pushAllTags(rootProject: Project) {
+    execGitCmd(rootProject, "push", "--all", "--follow-tags")
+  }
+
 
   override fun toString(): String {
     return String.format("  %1$-30s : include = %2$-5s, update = %3$-5s, branch = %4$-20s, path = %5$-30s, url = %6\$s", name, include, update, branch, dirPath, url)

--- a/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repo.kt
@@ -79,7 +79,7 @@ class Repo(
     execGitCmd(rootProject, "push")
   }
 
-  fun pushAllTags(rootProject: Project) {
+  fun pushTags(rootProject: Project) {
     execGitCmd(rootProject, "push", "--follow-tags")
   }
 


### PR DESCRIPTION
- Rename `pushAllTags()` to `pushTags()`, as it doesn't push all branches and tags, but only the local branch and tags.
- Add `pushAllTags()` that pushes all branches and tags.
- Add `--autostash` to `git pull` to stash changes and pop the stash on top of the pulled branch, see [Git tip: autostash with git pull --rebase](https://cscheng.info/2017/01/26/git-tip-autostash-with-git-pull-rebase.html)
- Change `push --tags` to `push --follow-tags`, see [How do we push tags](https://vivaxyblog.github.io/2019/08/02/git-tag-and-push-git-tag.html#so-how-do-we-push-tags)