### PR TITLE
Add fetch on update

### DIFF
--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -79,6 +79,7 @@ class DevenvRepositoriesPlugin : Plugin<Project> {
             repo.clone(project)
           } else {
             println("Updating repository $repo:")
+            repo.fetch(project)
             repo.checkout(project)
             repo.pull(project)
           }


### PR DESCRIPTION
A simple PR to add `git fetch` before `git checkout` when doing `./repo update`. Without `git fetch`, the branch that has been set in `repo.properties` might not be known yet, and the checkout will fail.