### PR TITLE
Short status task

### DIFF
--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -151,7 +151,6 @@ open class RepositoryTask : DefaultTask() {
 
 class StatusRepositoryTask : RepositoryTask() {
   @Input
-  @Optional
   @Option(option = "short", description = "Print short status info.")
   var short: Boolean = false
 }

--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -149,7 +149,7 @@ open class RepositoryTask : DefaultTask() {
   }
 }
 
-class StatusRepositoryTask : RepositoryTask() {
+open class StatusRepositoryTask : RepositoryTask() {
   @Input
   @Option(option = "short", description = "Print short status info.")
   var short: Boolean = false

--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -4,6 +4,9 @@ import org.eclipse.jgit.lib.internal.WorkQueue
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.*
 
 @Suppress("unused")
@@ -25,12 +28,12 @@ class DevenvRepositoriesPlugin : Plugin<Project> {
       }
       description = "Lists the repositories and their properties."
     }
-    project.tasks.register<RepositoryTask>("status") {
+    project.tasks.register<StatusRepositoryTask>("status") {
       doLast {
         for(repo in repositories.repositories.values) {
           if(!repo.update) continue
           println("Status for repository $repo:")
-          repo.status(project)
+          repo.status(project, short)
           println()
         }
       }
@@ -144,4 +147,11 @@ open class RepositoryTask : DefaultTask() {
   init {
     group = "Devenv repository"
   }
+}
+
+class StatusRepositoryTask : RepositoryTask() {
+  @Input
+  @Optional
+  @Option(option = "short", description = "Print short status info.")
+  var short: Boolean = false
 }

--- a/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
@@ -79,7 +79,7 @@ class Repository(
 
 
   fun status(rootProject: Project, short: Boolean = false) {
-    execGitCmd(rootProject, "status", if (short) "-sb" else "", printCommandLine = false)
+    execGitCmd(rootProject, "-c", "color.status=always", "status", if (short) "-sb" else "", printCommandLine = false)
   }
 
   fun clone(rootProject: Project) {

--- a/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
@@ -55,7 +55,7 @@ class Repository(
     rootProject.exec {
       this.executable = "git"
       this.workingDir = dir
-      this.args = args
+      this.args = args.filterNot { it.isBlank() }
       if(printCommandLine) {
         println(commandLine.joinToString(separator = " "))
       }
@@ -70,7 +70,7 @@ class Repository(
   fun execGitCmdInRoot(rootProject: Project, args: MutableList<String>, printCommandLine: Boolean = true) {
     rootProject.exec {
       this.executable = "git"
-      this.args = args
+      this.args = args.filterNot { it.isBlank() }
       if(printCommandLine) {
         println(commandLine.joinToString(separator = " "))
       }
@@ -78,8 +78,8 @@ class Repository(
   }
 
 
-  fun status(rootProject: Project) {
-    execGitCmd(rootProject, "status", printCommandLine = false)
+  fun status(rootProject: Project, short: Boolean = false) {
+    execGitCmd(rootProject, "status", if (short) "-sb" else "", printCommandLine = false)
   }
 
   fun clone(rootProject: Project) {


### PR DESCRIPTION
This PR adds the `--short` option to the `./repo status` command, for more concise output. It also ensures the output is colored like how git would normally.