### PR TITLE
Clean task

### DIFF
--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -160,7 +160,7 @@ open class RepositoryTask : DefaultTask() {
   }
 }
 
-class CleanRepositoryTask : RepositoryTask() {
+open class CleanRepositoryTask : RepositoryTask() {
   @Input
   @Option(option = "force", description = "Performs the clean without a dry-run.")
   var force: Boolean = false

--- a/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/DevenvRepositoriesPlugin.kt
@@ -162,12 +162,10 @@ open class RepositoryTask : DefaultTask() {
 
 class CleanRepositoryTask : RepositoryTask() {
   @Input
-  @Optional
   @Option(option = "force", description = "Performs the clean without a dry-run.")
   var force: Boolean = false
 
   @Input
-  @Optional
   @Option(option = "removeIgnored", description = "Also remove ignored untracked files.")
   var removeIgnored: Boolean = false
 }

--- a/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
@@ -55,7 +55,7 @@ class Repository(
     rootProject.exec {
       this.executable = "git"
       this.workingDir = dir
-      this.args = args
+      this.args = args.filterNot { it.isBlank() }
       if(printCommandLine) {
         println(commandLine.joinToString(separator = " "))
       }
@@ -70,7 +70,7 @@ class Repository(
   fun execGitCmdInRoot(rootProject: Project, args: MutableList<String>, printCommandLine: Boolean = true) {
     rootProject.exec {
       this.executable = "git"
-      this.args = args
+      this.args = args.filterNot { it.isBlank() }
       if(printCommandLine) {
         println(commandLine.joinToString(separator = " "))
       }
@@ -112,6 +112,14 @@ class Repository(
 
   fun pushAllTags(rootProject: Project) {
     execGitCmd(rootProject, "push", "--all", "--follow-tags")
+  }
+
+  fun clean(rootProject: Project, dryRun: Boolean, removeUntracked: Boolean = false) {
+    // -X: remove untracked files
+    // -x: remove untracked and ignored untracked files
+    // -d: remove untracked directories
+    execGitCmd(rootProject, "clean", "--force", if (removeUntracked) "-x" else "-X", "-d",
+      if (dryRun) "--dry-run" else "")
   }
 
   fun info() =

--- a/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
+++ b/src/main/kotlin/mb/gradle/config/devenv/Repository.kt
@@ -114,11 +114,11 @@ class Repository(
     execGitCmd(rootProject, "push", "--all", "--follow-tags")
   }
 
-  fun clean(rootProject: Project, dryRun: Boolean, removeUntracked: Boolean = false) {
+  fun clean(rootProject: Project, dryRun: Boolean, removeIgnored: Boolean = false) {
     // -X: remove untracked files
     // -x: remove untracked and ignored untracked files
     // -d: remove untracked directories
-    execGitCmd(rootProject, "clean", "--force", if (removeUntracked) "-x" else "-X", "-d",
+    execGitCmd(rootProject, "clean", "--force", if (removeIgnored) "-x" else "-X", "-d",
       if (dryRun) "--dry-run" else "")
   }
 


### PR DESCRIPTION
This PR adds a `./repo clean` task. By default, the task only shows what it would clean. Execute it as `./repo clean --force` to actually clean. Use the `--removeIgnored` to also remove ignored untracked files.